### PR TITLE
docs(readme): add a used by section

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: gouravkhunger/dependents.info@main
+      - uses: gouravkhunger/dependents.info@0.1.3

--- a/README.md
+++ b/README.md
@@ -3,10 +3,17 @@
 [![Version](https://img.shields.io/npm/v/astro-better-image-service)](https://www.npmjs.com/package/astro-better-image-service)
 [![License](https://img.shields.io/npm/l/astro-better-image-service)](https://github.com/risu729/astro-better-image-service?tab=License-1-ov-file)
 [![NPM Downloads](https://img.shields.io/npm/dm/astro-better-image-service)](https://www.npmjs.com/package/astro-better-image-service)
+[![Network Dependents](https://dependents.info/risu729/astro-better-image-service/badge)](https://dependents.info/risu729/astro-better-image-service)
 [![Last commit](https://img.shields.io/github/last-commit/risu729/astro-better-image-service)](https://github.com/risu729/astro-better-image-service/commits/main/)
 [![Repo stars](https://img.shields.io/github/stars/risu729/astro-better-image-service)](https://github.com/risu729/astro-better-image-service/stargazers)
 
 **`astro-better-image-service`** is an Astro integration for image compression and conversion, superseding Astro's default image service.
+
+## 🧑‍💻 Used by
+
+<a href="https://dependents.info/risu729/astro-better-image-service">
+  <img src="https://dependents.info/risu729/astro-better-image-service/image" />
+</a>
 
 ## 🖼️ Features
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a beautiful "Used by" section in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built myself: [dependents.info](https://dependents.info). Here's an example of how the image renders:

## Used by

![github network dependents image generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/image.svg)

There's also a shield.io based badge if you prefer the smaller variant.

![github network dependents total count generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/badge)

for your project they'll look like

<img width="540" alt="image" src="https://github.com/user-attachments/assets/579480ed-0ab1-4d28-8e77-19fa3c877886" />

Please feel free to close the PR if you don't want to have this!